### PR TITLE
Accept '\e[m' as a reset token

### DIFF
--- a/lib/ansispan.js
+++ b/lib/ansispan.js
@@ -24,6 +24,7 @@ var ansispan = function (str) {
   //
   str = str.replace(/\033\[3m/g, '<i>').replace(/\033\[23m/g, '</i>');
 
+  str = str.replace(/\033\[m/g, '</span>');
   return str.replace(/\033\[39m/g, '</span>');
 };
 


### PR DESCRIPTION
Hi,

I had to add an additional ANSI reset token in order to use this on the output of "brunch".
- Jesse Clark
