### PR TITLE
Added a regex to close on the reset code

### DIFF
--- a/lib/ansispan.js
+++ b/lib/ansispan.js
@@ -25,6 +25,7 @@ var ansispan = function (str) {
   str = str.replace(/\033\[3m/g, '<i>').replace(/\033\[23m/g, '</i>');
 
   str = str.replace(/\033\[m/g, '</span>');
+  str = str.replace(/\033\[0m/g, '</span>');
   return str.replace(/\033\[39m/g, '</span>');
 };
 

--- a/test/ansispan-test.js
+++ b/test/ansispan-test.js
@@ -25,6 +25,10 @@ var dataSets = {
     input: '\033\[0;32mhello world\033\[39m',
     output: '<span style="color: green">hello world</span>'
   },
+  'colors with reset bit': {
+    input: '\033[35mhello world\033[0m',
+    output: '<span style="color: purple">hello world</span>'
+  },
   bold: {
     input: 'hello world'.bold,
     output: '<b>hello world</b>'


### PR DESCRIPTION
The Ansi reset code `0` should close the span since it's a "reset to normal color" flag.

I patched this, and added a test case for it.
