### PR TITLE
Prevent missmatching close-tags

### DIFF
--- a/lib/ansispan.js
+++ b/lib/ansispan.js
@@ -17,15 +17,15 @@ var ansispan = function (str) {
   //
   // `\033[1m` enables bold font, `\033[22m` disables it
   //
-  str = str.replace(/\033\[1m/g, '<b>').replace(/\033\[22m/g, '</b>');
+  str = str.replace(/\033\[1m/g, '<span style="font-weight:bold;">').replace(/\033\[22m/g, '</span>');
 
   //
   // `\033[3m` enables italics font, `\033[23m` disables it
   //
-  str = str.replace(/\033\[3m/g, '<i>').replace(/\033\[23m/g, '</i>');
+  str = str.replace(/\033\[3m/g, '<span style="font-style:italic;">').replace(/\033\[23m/g, '</span>');
 
   str = str.replace(/\033\[m/g, '</span>');
-  str = str.replace(/\033\[0m/g, '</span>');
+  str = str.replace(/\033\[0m/g, '</span>'); // also closes bold and italics
   return str.replace(/\033\[39m/g, '</span>');
 };
 


### PR DESCRIPTION
`[0m` can also mean `</b>` - so use always spans
